### PR TITLE
Added get_neighbor_cell_ids function

### DIFF
--- a/s2cell/s2cell.py
+++ b/s2cell/s2cell.py
@@ -12,13 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# pylint: disable=too-many-lines
+
 """Minimal Python S2 Geometry cell ID, token and lat/lon conversion library."""
 
 import math
 import re
 from typing import Optional, Tuple
 
-# pylint: disable=too-many-lines
 
 #
 # s2cell exceptions

--- a/s2cell/s2cell.py
+++ b/s2cell/s2cell.py
@@ -1125,7 +1125,7 @@ def cell_id_to_neighbor_cell_ids(
     ]
 
     for di, dj, is_corner in offsets:
-        # All edge neighbors are always inluded
+        # All edge neighbors are always included when requested
         if not is_corner and edge:
             neighbors.append(_s2_face_ij_to_wrapped_cell_id(face, i + di, j + dj, level))
 

--- a/s2cell/s2cell.py
+++ b/s2cell/s2cell.py
@@ -1092,6 +1092,10 @@ def cell_id_to_neighbor_cell_ids(
     By default, only edge neighbors are returned from this function, unless
     corner is True.
 
+    If only edge neighbors are requested, the order of the returned cell IDs is
+    guaranteed to be in the order down, right, up, left from the input cell ID,
+    to match the behaviour of s2geometry GetEdgeNeighbors().
+
     See s2geometry/blob/2c02e21040e0b82aa5719e96033d02b8ce7c0eff/src/s2/s2cell_id.cc#L545-L586
 
     Args:

--- a/s2cell/s2cell.py
+++ b/s2cell/s2cell.py
@@ -997,7 +997,7 @@ def get_neighbor_cell_ids(
     cell_id: int, edge: bool = True, corners: bool = False
 ) -> list[int]:
     """
-    Lists neighbor cells for input cell.
+    List neighbor cells for input cell.
 
     There are two types of neighbors: edge neighbors and corner neighbors.
     By default, only edge neighbors are returned. If corners is True, corner

--- a/tests/test_s2cell.py
+++ b/tests/test_s2cell.py
@@ -336,3 +336,70 @@ def test_token_to_parent_token_compat():
                 else:
                     with pytest.raises(ValueError, match=re.escape('Cannot get level {} parent cell ID of cell ID with level {}'.format(other_level, level))):
                         s2cell.token_to_parent_token(levels_dict[level], other_level)
+
+
+def test_s2_get_edge_neighbors():
+    # s2geometry/blob/7773d518b1f29caa1c2045eb66ec519e025be108/src/python/s2geometry_test.py#L66-L73
+    cell = 0x466d319000000000
+    expected_neighbors = sorted([0x466d31b000000000,
+                                 0x466d317000000000,
+                                 0x466d323000000000,
+                                 0x466d31f000000000])
+    neighbors = sorted(s2cell.get_neighbor_cell_ids(cell))
+    assert len(neighbors) == len(expected_neighbors)
+    for i in range(len(neighbors)):
+        assert neighbors[i] == expected_neighbors[i]
+
+
+def test_s2_get_edge_neighbors_all_neighbors():
+    # s2geometry/blob/7773d518b1f29caa1c2045eb66ec519e025be108/src/python/s2geometry_test.py#L86-L99
+    cell = 0x466d319000000000
+    expected_neighbors = sorted([0x466d31d000000000,
+                                 0x466d311000000000,
+                                 0x466d31b000000000,
+                                 0x466d323000000000,
+                                 0x466d31f000000000,
+                                 0x466d317000000000,
+                                 0x466d321000000000,
+                                 0x466d33d000000000])
+    assert s2cell.cell_id_to_level(cell) == 12
+    neighbors = sorted(s2cell.get_neighbor_cell_ids(cell, corners=True))
+    assert len(neighbors) == len(expected_neighbors)
+    for i in range(len(neighbors)):
+        assert neighbors[i] == expected_neighbors[i]
+
+    # s2geometry/blob/7773d518b1f29caa1c2045eb66ec519e025be108/src/python/s2geometry_test.py#L146-L157
+    cell = 0x6aa7590000000000
+    expected_neighbors = sorted([0x2ab3530000000000,
+                                 0x2ab34b0000000000,
+                                 0x2ab34d0000000000,
+                                 0x6aa75b0000000000,
+                                 0x6aa7570000000000,
+                                 0x6aa75f0000000000,
+                                 0x6aa7510000000000,
+                                 0x6aa75d0000000000])
+    neighbors = sorted(s2cell.get_neighbor_cell_ids(cell, corners=True))
+    assert len(neighbors) == len(expected_neighbors)
+    for i in range(len(neighbors)):
+        assert neighbors[i] == expected_neighbors[i]
+
+
+def test_s2_get_edge_neighbors_at_cube_corner():
+    cell = 0x4aac000000000000
+
+    expected_neighbors = sorted([0x0aac000000000000,
+                                 0x4aa4000000000000,
+                                 0x4ab4000000000000,
+                                 0x8aac000000000000])
+    neighbors = sorted(s2cell.get_neighbor_cell_ids(cell, edge=True, corners=False))
+    assert len(neighbors) == len(expected_neighbors)
+    for i in range(len(neighbors)):
+        assert neighbors[i] == expected_neighbors[i]
+
+    expected_neighbors = sorted([0x0ab4000000000000,
+                                 0x4abc000000000000,
+                                 0x8aa4000000000000])
+    neighbors = sorted(s2cell.get_neighbor_cell_ids(cell, edge=False, corners=True))
+    assert len(neighbors) == len(expected_neighbors)
+    for i in range(len(neighbors)):
+        assert neighbors[i] == expected_neighbors[i]

--- a/tests/test_s2cell.py
+++ b/tests/test_s2cell.py
@@ -345,7 +345,7 @@ def test_s2_get_edge_neighbors():
                                  0x466d317000000000,
                                  0x466d323000000000,
                                  0x466d31f000000000])
-    neighbors = sorted(s2cell.get_neighbor_cell_ids(cell))
+    neighbors = sorted(s2cell.cell_id_to_neighbor_cell_ids(cell))
     assert len(neighbors) == len(expected_neighbors)
     for i in range(len(neighbors)):
         assert neighbors[i] == expected_neighbors[i]
@@ -363,7 +363,7 @@ def test_s2_get_edge_neighbors_all_neighbors():
                                  0x466d321000000000,
                                  0x466d33d000000000])
     assert s2cell.cell_id_to_level(cell) == 12
-    neighbors = sorted(s2cell.get_neighbor_cell_ids(cell, corners=True))
+    neighbors = sorted(s2cell.cell_id_to_neighbor_cell_ids(cell, corner=True))
     assert len(neighbors) == len(expected_neighbors)
     for i in range(len(neighbors)):
         assert neighbors[i] == expected_neighbors[i]
@@ -378,7 +378,7 @@ def test_s2_get_edge_neighbors_all_neighbors():
                                  0x6aa75f0000000000,
                                  0x6aa7510000000000,
                                  0x6aa75d0000000000])
-    neighbors = sorted(s2cell.get_neighbor_cell_ids(cell, corners=True))
+    neighbors = sorted(s2cell.cell_id_to_neighbor_cell_ids(cell, corner=True))
     assert len(neighbors) == len(expected_neighbors)
     for i in range(len(neighbors)):
         assert neighbors[i] == expected_neighbors[i]
@@ -391,7 +391,7 @@ def test_s2_get_edge_neighbors_at_cube_corner():
                                  0x4aa4000000000000,
                                  0x4ab4000000000000,
                                  0x8aac000000000000])
-    neighbors = sorted(s2cell.get_neighbor_cell_ids(cell, edge=True, corners=False))
+    neighbors = sorted(s2cell.cell_id_to_neighbor_cell_ids(cell, edge=True, corner=False))
     assert len(neighbors) == len(expected_neighbors)
     for i in range(len(neighbors)):
         assert neighbors[i] == expected_neighbors[i]
@@ -399,7 +399,7 @@ def test_s2_get_edge_neighbors_at_cube_corner():
     expected_neighbors = sorted([0x0ab4000000000000,
                                  0x4abc000000000000,
                                  0x8aa4000000000000])
-    neighbors = sorted(s2cell.get_neighbor_cell_ids(cell, edge=False, corners=True))
+    neighbors = sorted(s2cell.cell_id_to_neighbor_cell_ids(cell, edge=False, corner=True))
     assert len(neighbors) == len(expected_neighbors)
     for i in range(len(neighbors)):
         assert neighbors[i] == expected_neighbors[i]

--- a/tests/test_s2cell.py
+++ b/tests/test_s2cell.py
@@ -341,7 +341,7 @@ def test_token_to_parent_token_compat():
 def test_s2_cell_id_to_neighbor_cell_ids_edge():
     # s2geometry/blob/7773d518b1f29caa1c2045eb66ec519e025be108/src/python/s2geometry_test.py#L66-L73
     cell = 0x466d319000000000
-    expected_neighbors = [  # Order is guaranteed for edge only
+    expected_neighbors = [
         0x466d31b000000000,
         0x466d317000000000,
         0x466d323000000000,
@@ -354,51 +354,51 @@ def test_s2_cell_id_to_neighbor_cell_ids_edge():
 def test_s2_cell_id_to_neighbor_cell_ids_all():
     # s2geometry/blob/7773d518b1f29caa1c2045eb66ec519e025be108/src/python/s2geometry_test.py#L86-L99
     cell = 0x466d319000000000
-    expected_neighbors = {  # Order is not guaranteed for non-edge only
-        0x466d31d000000000,
-        0x466d311000000000,
-        0x466d31b000000000,
-        0x466d323000000000,
-        0x466d31f000000000,
-        0x466d317000000000,
-        0x466d321000000000,
-        0x466d33d000000000,
-    }
+    expected_neighbors = [
+        5074766987100422144,
+        5074766299905654784,
+        5074766712222515200,
+        5074769323562631168,
+        5074767536856236032,
+        5074767399417282560,
+        5074767261978329088,
+        5074767124539375616,
+    ]
     assert s2cell.cell_id_to_level(cell) == 12
-    neighbors = set(s2cell.cell_id_to_neighbor_cell_ids(cell, corner=True))
+    neighbors = s2cell.cell_id_to_neighbor_cell_ids(cell, corner=True)
     assert neighbors == expected_neighbors
 
     # s2geometry/blob/7773d518b1f29caa1c2045eb66ec519e025be108/src/python/s2geometry_test.py#L146-L157
     cell = 0x6aa7590000000000
-    expected_neighbors = {  # Order is not guaranteed for non-edge only
-        0x2ab3530000000000,
-        0x2ab34b0000000000,
-        0x2ab34d0000000000,
-        0x6aa75b0000000000,
-        0x6aa7570000000000,
-        0x6aa75f0000000000,
-        0x6aa7510000000000,
-        0x6aa75d0000000000,
-    }
-    neighbors = sorted(s2cell.cell_id_to_neighbor_cell_ids(cell, corner=True))
+    expected_neighbors = [
+        3076887632819519488,
+        3076885433796263936,
+        7685215742735679488,
+        7685213543712423936,
+        7685211344689168384,
+        7685200349572890624,
+        7685206946642657280,
+        3076894229889286144,
+    ]
+    neighbors = s2cell.cell_id_to_neighbor_cell_ids(cell, corner=True)
     assert neighbors == expected_neighbors
 
 
 def test_s2_cell_id_to_neighbor_cell_ids_at_cube_corner():
     cell = 0x4aac000000000000
-    expected_neighbors = [  # Order is guaranteed for edge only
-        0x0aac000000000000,
+    expected_neighbors = [
         0x4aa4000000000000,
         0x4ab4000000000000,
         0x8aac000000000000,
+        0x0aac000000000000,
     ]
     neighbors = s2cell.cell_id_to_neighbor_cell_ids(cell, edge=True, corner=False)
     assert neighbors == expected_neighbors
 
-    expected_neighbors = {
-        0x0ab4000000000000,
-        0x4abc000000000000,
-        0x8aa4000000000000,
-    }
-    neighbors = set(s2cell.cell_id_to_neighbor_cell_ids(cell, edge=False, corner=True))
+    expected_neighbors = [
+        5385179254428270592,
+        9990109873414602752,
+        771241436187197440,
+    ]
+    neighbors = s2cell.cell_id_to_neighbor_cell_ids(cell, edge=False, corner=True)
     assert neighbors == expected_neighbors

--- a/tests/test_s2cell.py
+++ b/tests/test_s2cell.py
@@ -351,7 +351,7 @@ def test_s2_cell_id_to_neighbor_cell_ids_edge():
     assert neighbors == expected_neighbors
 
 
-def test_s2_cell_id_to_neighbor_cell_ids_all():
+def test_cell_id_to_neighbor_cell_ids_all():
     # s2geometry/blob/7773d518b1f29caa1c2045eb66ec519e025be108/src/python/s2geometry_test.py#L86-L99
     cell = 0x466d319000000000
     expected_neighbors = [
@@ -384,7 +384,7 @@ def test_s2_cell_id_to_neighbor_cell_ids_all():
     assert neighbors == expected_neighbors
 
 
-def test_s2_cell_id_to_neighbor_cell_ids_at_cube_corner():
+def test_cell_id_to_neighbor_cell_ids_at_cube_corner():
     cell = 0x4aac000000000000
     expected_neighbors = [
         0x4aa4000000000000,
@@ -402,3 +402,14 @@ def test_s2_cell_id_to_neighbor_cell_ids_at_cube_corner():
     ]
     neighbors = s2cell.cell_id_to_neighbor_cell_ids(cell, edge=False, corner=True)
     assert neighbors == expected_neighbors
+
+
+def test_cell_id_to_neighbor_cell_ids_compat():
+    # Check against generated S2 tests
+    encode_file = pathlib.Path(__file__).parent / 's2_neighbor_corpus.csv.gz'
+    with gzip.open(str(encode_file), 'rt') as f:
+        for row in csv.DictReader(f):
+            edge_neighbors = {int(cell_id) for cell_id in row['edge_neighbors'].split(':')}
+            all_neighbors = {int(cell_id) for cell_id in row['all_neighbors'].split(':')}
+            assert set(s2cell.cell_id_to_neighbor_cell_ids(int(row['cell_id']))) == edge_neighbors
+            assert set(s2cell.cell_id_to_neighbor_cell_ids(int(row['cell_id']), corner=True)) == all_neighbors

--- a/tests/test_s2cell.py
+++ b/tests/test_s2cell.py
@@ -338,68 +338,67 @@ def test_token_to_parent_token_compat():
                         s2cell.token_to_parent_token(levels_dict[level], other_level)
 
 
-def test_s2_get_edge_neighbors():
+def test_s2_cell_id_to_neighbor_cell_ids_edge():
     # s2geometry/blob/7773d518b1f29caa1c2045eb66ec519e025be108/src/python/s2geometry_test.py#L66-L73
     cell = 0x466d319000000000
-    expected_neighbors = sorted([0x466d31b000000000,
-                                 0x466d317000000000,
-                                 0x466d323000000000,
-                                 0x466d31f000000000])
-    neighbors = sorted(s2cell.cell_id_to_neighbor_cell_ids(cell))
-    assert len(neighbors) == len(expected_neighbors)
-    for i in range(len(neighbors)):
-        assert neighbors[i] == expected_neighbors[i]
+    expected_neighbors = [  # Order is guaranteed for edge only
+        0x466d31b000000000,
+        0x466d317000000000,
+        0x466d323000000000,
+        0x466d31f000000000,
+    ]
+    neighbors = s2cell.cell_id_to_neighbor_cell_ids(cell)
+    assert neighbors == expected_neighbors
 
 
-def test_s2_get_edge_neighbors_all_neighbors():
+def test_s2_cell_id_to_neighbor_cell_ids_all():
     # s2geometry/blob/7773d518b1f29caa1c2045eb66ec519e025be108/src/python/s2geometry_test.py#L86-L99
     cell = 0x466d319000000000
-    expected_neighbors = sorted([0x466d31d000000000,
-                                 0x466d311000000000,
-                                 0x466d31b000000000,
-                                 0x466d323000000000,
-                                 0x466d31f000000000,
-                                 0x466d317000000000,
-                                 0x466d321000000000,
-                                 0x466d33d000000000])
+    expected_neighbors = {  # Order is not guaranteed for non-edge only
+        0x466d31d000000000,
+        0x466d311000000000,
+        0x466d31b000000000,
+        0x466d323000000000,
+        0x466d31f000000000,
+        0x466d317000000000,
+        0x466d321000000000,
+        0x466d33d000000000,
+    }
     assert s2cell.cell_id_to_level(cell) == 12
-    neighbors = sorted(s2cell.cell_id_to_neighbor_cell_ids(cell, corner=True))
-    assert len(neighbors) == len(expected_neighbors)
-    for i in range(len(neighbors)):
-        assert neighbors[i] == expected_neighbors[i]
+    neighbors = set(s2cell.cell_id_to_neighbor_cell_ids(cell, corner=True))
+    assert neighbors == expected_neighbors
 
     # s2geometry/blob/7773d518b1f29caa1c2045eb66ec519e025be108/src/python/s2geometry_test.py#L146-L157
     cell = 0x6aa7590000000000
-    expected_neighbors = sorted([0x2ab3530000000000,
-                                 0x2ab34b0000000000,
-                                 0x2ab34d0000000000,
-                                 0x6aa75b0000000000,
-                                 0x6aa7570000000000,
-                                 0x6aa75f0000000000,
-                                 0x6aa7510000000000,
-                                 0x6aa75d0000000000])
+    expected_neighbors = {  # Order is not guaranteed for non-edge only
+        0x2ab3530000000000,
+        0x2ab34b0000000000,
+        0x2ab34d0000000000,
+        0x6aa75b0000000000,
+        0x6aa7570000000000,
+        0x6aa75f0000000000,
+        0x6aa7510000000000,
+        0x6aa75d0000000000,
+    }
     neighbors = sorted(s2cell.cell_id_to_neighbor_cell_ids(cell, corner=True))
-    assert len(neighbors) == len(expected_neighbors)
-    for i in range(len(neighbors)):
-        assert neighbors[i] == expected_neighbors[i]
+    assert neighbors == expected_neighbors
 
 
-def test_s2_get_edge_neighbors_at_cube_corner():
+def test_s2_cell_id_to_neighbor_cell_ids_at_cube_corner():
     cell = 0x4aac000000000000
+    expected_neighbors = [  # Order is guaranteed for edge only
+        0x0aac000000000000,
+        0x4aa4000000000000,
+        0x4ab4000000000000,
+        0x8aac000000000000,
+    ]
+    neighbors = s2cell.cell_id_to_neighbor_cell_ids(cell, edge=True, corner=False)
+    assert neighbors == expected_neighbors
 
-    expected_neighbors = sorted([0x0aac000000000000,
-                                 0x4aa4000000000000,
-                                 0x4ab4000000000000,
-                                 0x8aac000000000000])
-    neighbors = sorted(s2cell.cell_id_to_neighbor_cell_ids(cell, edge=True, corner=False))
-    assert len(neighbors) == len(expected_neighbors)
-    for i in range(len(neighbors)):
-        assert neighbors[i] == expected_neighbors[i]
-
-    expected_neighbors = sorted([0x0ab4000000000000,
-                                 0x4abc000000000000,
-                                 0x8aa4000000000000])
-    neighbors = sorted(s2cell.cell_id_to_neighbor_cell_ids(cell, edge=False, corner=True))
-    assert len(neighbors) == len(expected_neighbors)
-    for i in range(len(neighbors)):
-        assert neighbors[i] == expected_neighbors[i]
+    expected_neighbors = {
+        0x0ab4000000000000,
+        0x4abc000000000000,
+        0x8aa4000000000000,
+    }
+    neighbors = set(s2cell.cell_id_to_neighbor_cell_ids(cell, edge=False, corner=True))
+    assert neighbors == expected_neighbors


### PR DESCRIPTION
This PR introduces a function to generate neighbor cell ids.

Usage:
```py
cell_id = s2cell.token_to_cell_id("1004")
edge_neighbors = s2cell.get_neighbor_cell_ids(cell_id, edge=True, corners=False)
corner_neighbors = s2cell.get_neighbor_cell_ids(cell_id, edge=False, corners=True)
```

Where:

`cell_id`: [1004](https://igorgatis.github.io/ws2/?cells=1004)
![image](https://github.com/aaliddell/s2cell/assets/1269388/82c266e3-389f-41bc-8095-a74633e88cb8)

`edge_neighbors`:  [1aac, 100c, 101c, 0ffc](https://igorgatis.github.io/ws2/?cells=1aac,100c,101c,0ffc)
![image](https://github.com/aaliddell/s2cell/assets/1269388/3c1d2cdd-33dc-4481-b253-ec17fc5d73e8)

`corner_neighbors`: [0554, 0fe4, 1aa4, 1014](https://igorgatis.github.io/ws2/?cells=0554,0fe4,1aa4,1014)
![image](https://github.com/aaliddell/s2cell/assets/1269388/5b253e2e-d9f2-48b0-a7ce-2c26fcb5feed)

The corner case:
Edge neighbors of [0aac](https://igorgatis.github.io/ws2/?cells=0aac,4aa4,4aac,4ab4,8aac)
![image](https://github.com/aaliddell/s2cell/assets/1269388/aacb54ce-6170-4c74-9bdb-b40b054e3b24)

Corner neighbors of [0aac](https://igorgatis.github.io/ws2/?cells=0ab4,4aac,4abc,8aa4)
![image](https://github.com/aaliddell/s2cell/assets/1269388/0bd73173-95e1-478c-87bd-5e5ec2b48b56)

